### PR TITLE
Correct link to new repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,1 +1,1 @@
-libtorrent development lives at https://github.org/arvidn/libtorrent for now
+libtorrent development lives at https://github.com/arvidn/libtorrent for now


### PR DESCRIPTION
Hello,

The `README.rst` file links to `github.org`, which is not a valid domain.
This pull request corrects the link to `github.com`.

Kind regards